### PR TITLE
Accept Pillow as a replacement for PIL when loading textures.

### DIFF
--- a/gletools/texture.py
+++ b/gletools/texture.py
@@ -15,7 +15,11 @@ try:
     import Image
     has_pil = True
 except:
-    has_pil = False
+    try:
+        from PIL import Image
+        has_pil = True
+    except:
+        has_pil = False
 
 __all__ = ['Texture']
 


### PR DESCRIPTION
The Pillow fork of PIL only allows the "from PIL import Image" style of import, but it should be otherwise compatible. (http://python-pillow.github.io/)
